### PR TITLE
fix: quote python path on windows

### DIFF
--- a/ui/src/app/api/jobs/[jobID]/start/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/start/route.ts
@@ -113,7 +113,16 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
 
     if (isWindows) {
       // For Windows, use 'cmd.exe' to open a new command window
-      subprocess = spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/k', pythonPath, ...args], {
+      // Quote the python path so installations under "C:\\Program Files" work
+      const windowsArgs = [
+        '/c',
+        'start',
+        'cmd.exe',
+        '/k',
+        pythonPath.includes(' ') ? `"${pythonPath}"` : pythonPath,
+        ...args,
+      ];
+      subprocess = spawn('cmd.exe', windowsArgs, {
         env: {
           ...process.env,
           ...additionalEnv,


### PR DESCRIPTION
## Summary
- quote Windows python path so `C:\Program Files` installs work

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_689ddf0622dc83249c590a7d413995c9